### PR TITLE
Fix default setting of default GBP_DAT dir in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ ifndef GBP_SRC
 endif
 export GBP_SRC
 ifndef GBP_DAT
-  GBP_INC=$(GBP_DAT)/myData/
+  GBP_DAT=$(GBP_SRC)/myData/
 endif
 export GBP_DAT
 ifndef GBP_INC


### PR DESCRIPTION
This PR fixes the default GBP_DIR environment variable in the master Makefile.
