### PR TITLE
SID_fopen.c had wrong statement

### DIFF
--- a/gbpLib/gbpSID/SID_fopen.c
+++ b/gbpLib/gbpSID/SID_fopen.c
@@ -71,14 +71,14 @@ int SID_fopen(const char   *filename,
 #else
   (fp->fp)=fopen(filename,mode);
   if((fp->fp)!=NULL)
-    r_val==TRUE;
+    r_val=TRUE;
   else
     r_val=FALSE;
 #endif
 #else
   (fp->fp)=fopen(filename,mode);
   if((fp->fp)!=NULL)
-    r_val==TRUE;
+    r_val=TRUE;
   else
     r_val=FALSE;
 #endif


### PR DESCRIPTION
Was a comparison rather than an assignment. Don't think it affects the final result though, since `r_val` is set to `TRUE` at the top of the file. 